### PR TITLE
fix UTC issue

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -104,7 +104,7 @@ export class MarkdownTable {
       Number(arr[1]),
       arr[2],
       Number(arr[3]),
-      new Date(arr[4])
+      new Date(arr[4].replace(/-/g, '\/'))
     );
   }
 


### PR DESCRIPTION
This is a weird bug with timezones with an easy fix.

Problem:
When doing any change or even loading the current rep all dates would be decreased by one!

The reason for that is because javascript takes "XXXX-XX-XX" dates as UTC making the string date different:

<img width="494" alt="CleanShot 2022-08-09 at 21 57 38@2x" src="https://user-images.githubusercontent.com/2165828/183820466-e0da0c0c-0f03-48e4-a1d1-9fc5ddd14194.png">

The solution is to replace "-" for "/" before parsing to a new Date object, that way it will take the timezone into consideration.

